### PR TITLE
feat: Add extra credentialsExpires options

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-01-17T10:18:20.401Z\n"
-"PO-Revision-Date: 2025-01-17T10:18:20.402Z\n"
+"POT-Creation-Date: 2025-05-12T18:38:49.646Z\n"
+"PO-Revision-Date: 2025-05-12T18:38:49.646Z\n"
 
 msgid "Failed to load: {{error}}"
 msgstr "Failed to load: {{error}}"
@@ -611,6 +611,9 @@ msgstr "Application left-side footer"
 msgid "Application right-side footer"
 msgstr "Application right-side footer"
 
+msgid "Style (android)"
+msgstr "Style (android)"
+
 msgid "Style"
 msgstr "Style"
 
@@ -745,6 +748,24 @@ msgstr "6 months"
 
 msgid "12 months"
 msgstr "12 months"
+
+msgid "14 months"
+msgstr "14 months"
+
+msgid "16 months"
+msgstr "16 months"
+
+msgid "18 months"
+msgstr "18 months"
+
+msgid "20 months"
+msgstr "20 months"
+
+msgid "22 months"
+msgstr "22 months"
+
+msgid "24 months"
+msgstr "24 months"
 
 msgid "Send reminders to users before their password expires"
 msgstr "Send reminders to users before their password expires"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "settings-app",
-    "version": "100.4.2",
+    "version": "100.4.2-eyeseetea-fork-1",
     "description": "",
     "license": "BSD-3-Clause",
     "private": true,

--- a/src/settingsKeyMapping.js
+++ b/src/settingsKeyMapping.js
@@ -580,6 +580,12 @@ const settingsKeyMapping = {
             3: i18n.t('3 months'),
             6: i18n.t('6 months'),
             12: i18n.t('12 months'),
+            14: i18n.t('14 months'),
+            16: i18n.t('16 months'),
+            18: i18n.t('18 months'),
+            20: i18n.t('20 months'),
+            22: i18n.t('22 months'),
+            24: i18n.t('24 months'),
         },
     },
     credentialsExpiryAlert: {


### PR DESCRIPTION
**Required by**: https://app.clickup.com/t/8698yzc96

Add extra options for 14, 16, 18, 20, 22 and 24 months for the credential expiration option. Tested with dev.est.

Targeting version 100.4.2 which is the version running in the instance that needs this change.

If required, I could create a script to extend the translation strings for all the 35 `.po` files, or just providing translations for any required languages that are not English.